### PR TITLE
Upgraded to elemental.json and fixed IllegalAnnotationException

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE ivy-module [
-	<!ENTITY vaadin.version "7.4.1">
+	<!ENTITY vaadin.version "7.5.7">
 ]>
 <ivy-module version="2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE ivy-module [
-	<!ENTITY vaadin.version "7.1.10">
+	<!ENTITY vaadin.version "7.4.1">
 ]>
 <ivy-module version="2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/com/github/wolfie/history/DefaultServlet.java
+++ b/src/com/github/wolfie/history/DefaultServlet.java
@@ -1,8 +1,8 @@
 package com.github.wolfie.history;
 
-import javax.servlet.annotation.WebServlet;
-
 import com.vaadin.server.VaadinServlet;
+
+import javax.servlet.annotation.WebServlet;
 
 @WebServlet(urlPatterns = { "/VAADIN/*" }, asyncSupported = true)
 public class DefaultServlet extends VaadinServlet {

--- a/src/com/github/wolfie/history/HistoryExtension.java
+++ b/src/com/github/wolfie/history/HistoryExtension.java
@@ -13,6 +13,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonException;
 import elemental.json.JsonObject;
+import elemental.json.JsonNull;
 
 import com.github.wolfie.history.HistoryExtension.ErrorEvent.Type;
 import com.vaadin.annotations.JavaScript;

--- a/src/com/github/wolfie/history/HistoryExtension.java
+++ b/src/com/github/wolfie/history/HistoryExtension.java
@@ -373,7 +373,7 @@ public class HistoryExtension extends AbstractJavaScriptExtension {
                     try {
                         final String address = arguments.getString(1);
                         final JsonObject state;
-                        if (arguments.length() > 0 && arguments.get(0) != null) {
+                        if (arguments.length() > 0 && !(arguments.get(0) instanceof JsonNull) && arguments.get(0) != null) {
                             state = arguments.getObject(0);
                         } else {
                             state = null;

--- a/src/com/github/wolfie/history/navigatordemo/NavigatorUI.java
+++ b/src/com/github/wolfie/history/navigatordemo/NavigatorUI.java
@@ -1,7 +1,5 @@
 package com.github.wolfie.history.navigatordemo;
 
-import javax.servlet.annotation.WebServlet;
-
 import com.github.wolfie.history.HistoryExtension;
 import com.github.wolfie.history.tabledemo.AboutView;
 import com.github.wolfie.history.tabledemo.MyPojo;
@@ -20,6 +18,8 @@ import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.TabSheet.SelectedTabChangeEvent;
 import com.vaadin.ui.TabSheet.SelectedTabChangeListener;
 import com.vaadin.ui.UI;
+
+import javax.servlet.annotation.WebServlet;
 
 @SuppressWarnings("serial")
 @Title("Navigator Integration Example")

--- a/src/com/github/wolfie/history/simpledemo/SimpleHistoryUI.java
+++ b/src/com/github/wolfie/history/simpledemo/SimpleHistoryUI.java
@@ -1,11 +1,5 @@
 package com.github.wolfie.history.simpledemo;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.servlet.annotation.WebServlet;
-
 import com.github.wolfie.history.HistoryExtension;
 import com.github.wolfie.history.HistoryExtension.ErrorListener;
 import com.github.wolfie.history.HistoryExtension.PopStateEvent;
@@ -16,14 +10,12 @@ import com.vaadin.event.ShortcutAction.KeyCode;
 import com.vaadin.event.ShortcutListener;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinServlet;
-import com.vaadin.ui.Button;
+import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
-import com.vaadin.ui.FormLayout;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.Notification;
-import com.vaadin.ui.TextField;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
+
+import javax.servlet.annotation.WebServlet;
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 @Title("Simplified HTML5 History Demo")
@@ -69,7 +61,13 @@ public class SimpleHistoryUI extends UI {
          * we want to initialize the history state data with something we can
          * handle in our popstate listener
          */
-        history.replaceState(Collections.singletonMap(DATA_KEY, ""), getPage()
+//        final Map<String, String> newStateMap = Collections.singletonMap(DATA_KEY, "");
+        final Map<String, String> newStateMap = new HashMap<String, String>();
+        newStateMap.put(DATA_KEY, "");
+        final Class<?> componentType = newStateMap.getClass().getComponentType();
+        System.err.println(componentType);
+        System.err.println(componentType);
+        history.replaceState(newStateMap, getPage()
                 .getLocation().toString());
 
         setContent(layout);

--- a/src/com/github/wolfie/history/tabledemo/DemoData.java
+++ b/src/com/github/wolfie/history/tabledemo/DemoData.java
@@ -1,8 +1,8 @@
 package com.github.wolfie.history.tabledemo;
 
-import java.util.Random;
-
 import com.vaadin.data.util.BeanItemContainer;
+
+import java.util.Random;
 
 public class DemoData {
 

--- a/src/com/github/wolfie/history/tabledemo/TableHistoryUI.java
+++ b/src/com/github/wolfie/history/tabledemo/TableHistoryUI.java
@@ -1,5 +1,11 @@
 package com.github.wolfie.history.tabledemo;
 
+import javax.servlet.annotation.WebServlet;
+
+import elemental.json.Json;
+import elemental.json.JsonException;
+import elemental.json.JsonObject;
+
 import com.github.wolfie.history.HistoryExtension;
 import com.github.wolfie.history.HistoryExtension.PopStateEvent;
 import com.github.wolfie.history.HistoryExtension.PopStateListener;
@@ -14,12 +20,6 @@ import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.TabSheet.SelectedTabChangeEvent;
 import com.vaadin.ui.TabSheet.SelectedTabChangeListener;
 import com.vaadin.ui.UI;
-import elemental.json.JsonException;
-import elemental.json.JsonObject;
-import elemental.json.impl.JreJsonFactory;
-
-import javax.servlet.annotation.WebServlet;
-import java.util.Map;
 
 @SuppressWarnings("serial")
 @Title("Table HTML5 History Demo")
@@ -57,7 +57,7 @@ public class TableHistoryUI extends UI {
              * We could've used event.getStateAsMap as well, to get an
              * Map<String, String> instead.
              */
-            applySerializedState(event.getStateAsMap());
+            applySerializedState(event.getStateAsJson());
         }
     };
 
@@ -118,7 +118,7 @@ public class TableHistoryUI extends UI {
 
     /**
      * A flag that prevents event feedback loops when modifying internal state
-     * via {@link #applySerializedState(Map)}
+     * via {@link #applySerializedState(JsonObject)}
      */
     private boolean applyingSerializedState = false;
 
@@ -204,7 +204,7 @@ public class TableHistoryUI extends UI {
                 tableValueId = -1;
             }
 
-            final JsonObject state = new JreJsonFactory().createObject();
+            final JsonObject state = Json.createObject();
             state.put(VIEW_KEY, view);
             state.put(POJO_ID_KEY, tableValueId);
             return state;
@@ -221,7 +221,7 @@ public class TableHistoryUI extends UI {
      *            the state object that contains the information needed to
      *            modify the application's state
      */
-    private void applySerializedState(final Map<String,String> state) {
+    private void applySerializedState(final JsonObject state) {
         if (state == null) {
             return;
         }
@@ -229,8 +229,8 @@ public class TableHistoryUI extends UI {
         try {
             applyingSerializedState = true;
 
-            final int view = Integer.parseInt(state.get(VIEW_KEY));
-            final int pojoId = Integer.parseInt(POJO_ID_KEY);
+            final int view = (int)state.getNumber(VIEW_KEY);
+            final int pojoId = (int)state.getNumber(POJO_ID_KEY);
 
             switch (view) {
             case TABLE_VIEW_STATE_VALUE:

--- a/src/com/github/wolfie/history/tabledemo/TableHistoryUI.java
+++ b/src/com/github/wolfie/history/tabledemo/TableHistoryUI.java
@@ -1,10 +1,5 @@
 package com.github.wolfie.history.tabledemo;
 
-import javax.servlet.annotation.WebServlet;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import com.github.wolfie.history.HistoryExtension;
 import com.github.wolfie.history.HistoryExtension.PopStateEvent;
 import com.github.wolfie.history.HistoryExtension.PopStateListener;
@@ -19,6 +14,12 @@ import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.TabSheet.SelectedTabChangeEvent;
 import com.vaadin.ui.TabSheet.SelectedTabChangeListener;
 import com.vaadin.ui.UI;
+import elemental.json.JsonException;
+import elemental.json.JsonObject;
+import elemental.json.impl.JreJsonFactory;
+
+import javax.servlet.annotation.WebServlet;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 @Title("Table HTML5 History Demo")
@@ -56,7 +57,7 @@ public class TableHistoryUI extends UI {
              * We could've used event.getStateAsMap as well, to get an
              * Map<String, String> instead.
              */
-            applySerializedState(event.getStateAsJson());
+            applySerializedState(event.getStateAsMap());
         }
     };
 
@@ -117,7 +118,7 @@ public class TableHistoryUI extends UI {
 
     /**
      * A flag that prevents event feedback loops when modifying internal state
-     * via {@link #applySerializedState(JSONObject)}
+     * via {@link #applySerializedState(Map)}
      */
     private boolean applyingSerializedState = false;
 
@@ -179,11 +180,11 @@ public class TableHistoryUI extends UI {
             targetUrl += "?" + query;
         }
 
-        final JSONObject state = serializeState();
+        final JsonObject state = serializeState();
         history.pushState(state, targetUrl);
     }
 
-    private JSONObject serializeState() {
+    private JsonObject serializeState() {
         try {
             final int view;
             if (tabsheet.getSelectedTab() == tableView) {
@@ -203,12 +204,12 @@ public class TableHistoryUI extends UI {
                 tableValueId = -1;
             }
 
-            final JSONObject state = new JSONObject();
+            final JsonObject state = new JreJsonFactory().createObject();
             state.put(VIEW_KEY, view);
             state.put(POJO_ID_KEY, tableValueId);
             return state;
 
-        } catch (final JSONException e) {
+        } catch (final JsonException e) {
             throw new RuntimeException(e);
         }
     }
@@ -220,7 +221,7 @@ public class TableHistoryUI extends UI {
      *            the state object that contains the information needed to
      *            modify the application's state
      */
-    private void applySerializedState(final JSONObject state) {
+    private void applySerializedState(final Map<String,String> state) {
         if (state == null) {
             return;
         }
@@ -228,8 +229,8 @@ public class TableHistoryUI extends UI {
         try {
             applyingSerializedState = true;
 
-            final int view = state.getInt(VIEW_KEY);
-            final int pojoId = state.getInt(POJO_ID_KEY);
+            final int view = Integer.parseInt(state.get(VIEW_KEY));
+            final int pojoId = Integer.parseInt(POJO_ID_KEY);
 
             switch (view) {
             case TABLE_VIEW_STATE_VALUE:
@@ -245,7 +246,7 @@ public class TableHistoryUI extends UI {
 
             tableView.select(pojoId);
 
-        } catch (final JSONException e) {
+        } catch (final JsonException e) {
             throw new RuntimeException(e);
         } finally {
             applyingSerializedState = false;


### PR DESCRIPTION
Migrated from org.json to elemental.json, as introduced in Vaadin 7.4.0
Throw java.lang.IllegalArgumentException instead of com.sun.xml.internal.txw2.IllegalAnnotationException
Tested with Vaadin v. 7.5.7
