### PR TITLE
Compatible navigation manager + more consistent popstate

### DIFF
--- a/src/main/java/com/github/wolfie/history/NavManager.java
+++ b/src/main/java/com/github/wolfie/history/NavManager.java
@@ -1,0 +1,94 @@
+package com.github.wolfie.history;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import com.github.wolfie.history.HistoryExtension.PopStateEvent;
+import com.vaadin.navigator.NavigationStateManager;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.server.Page;
+import com.vaadin.ui.UI;
+
+/**
+ * Stores state in URL path, e.g. "host:port/viewname/some_state" 
+ */
+final class NavManager implements NavigationStateManager,
+        HistoryExtension.PopStateListener {
+
+	private final HistoryExtension historyExtension;
+	private final Map emptyStateObject = null;
+    private Navigator navigator;
+    private String state = null;
+    private final String urlRoot;
+    private String query;
+
+    public NavManager(HistoryExtension historyExtension, final String urlRoot) {
+        this.historyExtension = historyExtension;
+		this.urlRoot = urlRoot;
+        this.historyExtension.addPopStateListener(this);
+    }
+
+    @Override
+    public String getState() {
+        if (state == null) {
+            state = parseStateFrom(navigator.getUI());
+        }
+        return state;
+    }
+
+    @Override
+    public void setState(final String state) {
+        this.state = state;
+        final String pushStateUrl = urlRoot + "/" + state
+                + (query != null ? "?" + query : "");
+
+        this.historyExtension.pushState(emptyStateObject, pushStateUrl);
+    }
+
+    @Override
+    public void setNavigator(final Navigator navigator) {
+        this.navigator = navigator;
+    }
+
+    @Override
+    public void popState(final PopStateEvent event) {
+        state = parseStateFrom(event.getAddress());
+        navigator.navigateTo(state);
+    }
+
+    private String parseStateFrom(final UI ui) {
+        if (ui != null) {
+            final Page page = ui.getPage();
+            if (page != null) {
+                return parseStateFrom(page.getLocation());
+            } else {
+                Logger.getLogger(getClass().getName()).warning(
+                        "Could not parse a proper state string: "
+                        + "Page was null");
+            }
+        } else {
+            Logger.getLogger(getClass().getName()).warning(
+                    "Could not parse a proper state string: "
+                    + "UI was null");
+        }
+        return "";
+    }
+
+    private String parseStateFrom(final URI uri) {
+        final String path = uri.getPath();
+        if (!path.startsWith(urlRoot)) {
+            Logger.getLogger(getClass().getName()).warning(
+                    "URI " + uri + " doesn't start with the urlRoot "
+                    + urlRoot);
+            return "";
+        }
+
+        String parsedState = path.substring(urlRoot.length());
+        if (parsedState.startsWith("/")) {
+            parsedState = parsedState.substring(1);
+        }
+        query = uri.getQuery();
+        return parsedState;
+    }
+}

--- a/src/main/java/com/github/wolfie/history/UriFragmentNavManager.java
+++ b/src/main/java/com/github/wolfie/history/UriFragmentNavManager.java
@@ -1,0 +1,69 @@
+package com.github.wolfie.history;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import com.github.wolfie.history.HistoryExtension.PopStateEvent;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.Navigator.UriFragmentManager;
+
+/**
+ * Stores state in URL fragment, e.g. "host:port#!viewname/some_state". This
+ * creates compatible urls with Vaadins default {@link UriFragmentManager}.
+ */
+public class UriFragmentNavManager extends UriFragmentManager implements HistoryExtension.PopStateListener {
+
+    private static final String FRAGMENT_PREFIX = "!";
+    private final HistoryExtension historyExtension;
+    private final Map<String, String> emptyStateObject = null;
+    private Navigator navigator;
+    private URI lastAddress;
+
+    public UriFragmentNavManager(HistoryExtension historyExtension) {
+        super(historyExtension.getUI().getPage());
+        this.historyExtension = historyExtension;
+        lastAddress = historyExtension.getUI().getPage().getLocation();
+        this.historyExtension.addPopStateListener(this);
+    }
+
+    @Override
+    protected String getFragment() {
+        return lastAddress.getFragment();
+    }
+
+    @Override
+    protected void setFragment(String fragment) {
+        try {
+            URI newLocation = new URI(lastAddress.getScheme(), lastAddress.getUserInfo(), lastAddress.getHost(),
+                    lastAddress.getPort(), lastAddress.getPath(), lastAddress.getQuery(), fragment);
+            this.historyExtension.pushState(emptyStateObject, newLocation.toString());
+            navigator.getUI().getPage().updateLocation(newLocation.toString(), false);
+        } catch (URISyntaxException e) {
+            Logger.getLogger(getClass().getName()).warning("Could not create url from current: " + lastAddress);
+        }
+
+    }
+
+    @Override
+    public void setNavigator(final Navigator navigator) {
+        super.setNavigator(navigator);
+        this.navigator = navigator;
+    }
+
+    @Override
+    public void popState(final PopStateEvent event) {
+        lastAddress = event.getAddress();
+        navigator.navigateTo(parseStateFrom(event.getAddress()));
+    }
+
+    protected String parseStateFrom(final URI uri) {
+        if (uri.getFragment() != null && uri.getFragment().startsWith(FRAGMENT_PREFIX)) {
+            return uri.getFragment().substring(FRAGMENT_PREFIX.length());
+        } else {
+            return "";
+        }
+    }
+
+}


### PR DESCRIPTION
The added `UriFragmentNavManager` creates URLs that are compatible with the default Vaadin `UriFragmentManager`.

As browser behaviour for `popstate` is inconsistent, I fired events manually for `pushState`/`replaceState`. So  no URL change will be missed. Duplicate events are recognised by equal URL and are dismissed.